### PR TITLE
Allow defaultObject method to return null

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -554,6 +554,9 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
     }
 
     protected TokenImageSpan buildSpanForObject(Object obj) {
+        if (obj == null) {
+            return null;
+        }
         View tokenView = getViewForObject(obj);
         return new TokenImageSpan(tokenView, obj);
     }
@@ -575,6 +578,8 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         if (editable != null) {
             if (!allowDuplicates && objects.contains(tokenSpan.getToken())) {
                 editable.replace(start, end, " ");
+            } else if (tokenSpan == null) {
+                editable.replace(start, end, " ");
             } else {
                 QwertyKeyListener.markAsReplaced(editable, start, end, original);
                 editable.replace(start, end, ssb);
@@ -594,6 +599,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         post(new Runnable() {
             @Override
             public void run() {
+                if (object == null) return;
                 if (!allowDuplicates && objects.contains(object)) return;
 
                 SpannableStringBuilder ssb = buildSpannableForText(sourceText);


### PR DESCRIPTION
Allow defaultObject method to return null.
E.g. new objects are ot allowed, only select fom existing.

Issues:
#38 - Dont do anything in defaultObject()
#36 - disallowing "just any string" to be created as a token.
