### PR TITLE
Allow defaultObject method to return null.

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -576,9 +576,9 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         String original = TextUtils.substring(editable, start, end);
 
         if (editable != null) {
-            if (!allowDuplicates && objects.contains(tokenSpan.getToken())) {
+            if (tokenSpan == null) {
                 editable.replace(start, end, " ");
-            } else if (tokenSpan == null) {
+            } else if (!allowDuplicates && objects.contains(tokenSpan.getToken())) {
                 editable.replace(start, end, " ");
             } else {
                 QwertyKeyListener.markAsReplaced(editable, start, end, original);


### PR DESCRIPTION
Allow defaultObject method to return null.
E.g. new objects are ot allowed, only select fom existing.

Issues:
#38 - Dont do anything in defaultObject()
#36 - disallowing "just any string" to be created as a token.
