### PR TITLE
Use generics instead of unchecked casts for more type-safety

### DIFF
--- a/example/src/main/java/com/tokenautocomplete/example/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/example/ContactsCompletionView.java
@@ -17,7 +17,7 @@ import com.tokenautocomplete.TokenCompleteTextView;
  * Created on 9/12/13.
  * @author mgod
  */
-public class ContactsCompletionView extends TokenCompleteTextView {
+public class ContactsCompletionView extends TokenCompleteTextView<Person> {
 
     public ContactsCompletionView(Context context) {
         super(context);
@@ -32,18 +32,17 @@ public class ContactsCompletionView extends TokenCompleteTextView {
     }
 
     @Override
-    protected View getViewForObject(Object object) {
-        Person p = (Person)object;
+    protected View getViewForObject(Person person) {
 
         LayoutInflater l = (LayoutInflater)getContext().getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
         LinearLayout view = (LinearLayout)l.inflate(R.layout.contact_token, (ViewGroup)ContactsCompletionView.this.getParent(), false);
-        ((TextView)view.findViewById(R.id.name)).setText(p.getEmail());
+        ((TextView)view.findViewById(R.id.name)).setText(person.getEmail());
 
         return view;
     }
 
     @Override
-    protected Object defaultObject(String completionText) {
+    protected Person defaultObject(String completionText) {
         //Stupid simple example of guessing if we have an email or not
         int index = completionText.indexOf('@');
         if (index == -1) {

--- a/example/src/main/java/com/tokenautocomplete/example/TokenActivity.java
+++ b/example/src/main/java/com/tokenautocomplete/example/TokenActivity.java
@@ -39,7 +39,7 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
                 if (convertView == null) {
 
                     LayoutInflater l = (LayoutInflater)getContext().getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
-                    convertView = (View)l.inflate(R.layout.person_layout, parent, false);
+                    convertView = l.inflate(R.layout.person_layout, parent, false);
                 }
 
                 Person p = getItem(position);
@@ -50,9 +50,9 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
             }
 
             @Override
-            protected boolean keepObject(Person obj, String mask) {
+            protected boolean keepObject(Person person, String mask) {
                 mask = mask.toLowerCase();
-                return obj.getName().toLowerCase().startsWith(mask) || obj.getEmail().toLowerCase().startsWith(mask);
+                return person.getName().toLowerCase().startsWith(mask) || person.getEmail().toLowerCase().startsWith(mask);
             }
         };
 
@@ -70,9 +70,9 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
         removeButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                List<Object> objects = completionView.getObjects();
-                if (objects.size() > 0) {
-                    completionView.removeObject(objects.get(objects.size() - 1));
+                List<Person> people = completionView.getObjects();
+                if (people.size() > 0) {
+                    completionView.removeObject(people.get(people.size() - 1));
                 }
             }
         });

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -12,6 +12,11 @@ android {
         minSdkVersion 8
         targetSdkVersion 19
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 }
 
 task jar(type: Jar) {

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -258,7 +258,6 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
 
     boolean inInvalidate = false;
 
-
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
     @Override
     public void invalidate() {

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -682,13 +682,18 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         Editable text = getText();
         if (text == null) return;
 
-        if (Build.VERSION.SDK_INT < 14) {
+        //If the spanwatcher has been removed, we need to also manually trigger onSpanRemoved
+        TokenSpanWatcher[] spans = text.getSpans(0, text.length(), TokenSpanWatcher.class);
+        if (spans.length == 0) {
+            spanWatcher.onSpanRemoved(text, span, text.getSpanStart(span), text.getSpanEnd(span));
+        } else if (Build.VERSION.SDK_INT < 14) {
             //HACK: Need to manually trigger on Span removed if there is only 1 object
             //not sure if there's a cleaner way
             if (objects.size() == 1) {
                 spanWatcher.onSpanRemoved(text, span, text.getSpanStart(span), text.getSpanEnd(span));
             }
         }
+
         //Add 1 to the end because we put a " " at the end of the spans when adding them
         text.delete(text.getSpanStart(span), text.getSpanEnd(span) + 1);
     }


### PR DESCRIPTION
I've changed the library (and the example app) to use generics to enforce type-safety at compile time. This keeps you from having to cast every Object that comes back from the view. The app code becomes much cleaner at the expense of generic use and some object casting in the library.

Closes #46