### PR TITLE
Use object's implicit toString() to avoid potential NullPointerException.

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1062,7 +1062,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
             if (obj instanceof Serializable) {
                 serializables.add((Serializable)obj);
             } else {
-                System.out.println("Unable to save '" + obj.toString() + "'");
+                System.out.println("Unable to save '" + obj + "'");
             }
         }
         if (serializables.size() != objects.size()) {


### PR DESCRIPTION
I was seeing the following stack trace when using TokenAutoComplete... 

java.lang.NullPointerException
com.tokenautocomplete.TokenCompleteTextView.getSerializableObjects(TokenCompleteTextView.java:1031)
com.tokenautocomplete.TokenCompleteTextView.onSaveInstanceState(TokenCompleteTextView.java:1049)
android.view.View.dispatchSaveInstanceState(View.java:13117)
android.view.ViewGroup.dispatchSaveInstanceState(ViewGroup.java:2828)
android.view.ViewGroup.dispatchSaveInstanceState(ViewGroup.java:2828)
android.view.ViewGroup.dispatchSaveInstanceState(ViewGroup.java:2828)
android.view.View.saveHierarchyState(View.java:13100)
android.support.v4.app.FragmentManagerImpl.saveFragmentViewState(FragmentManager.java:1590)
android.support.v4.app.FragmentManagerImpl.saveFragmentBasicState(FragmentManager.java:1610)
android.support.v4.app.FragmentManagerImpl.saveAllState(FragmentManager.java:1671)
android.support.v4.app.FragmentActivity.onSaveInstanceState(FragmentActivity.java:532)
android.app.Activity.performSaveInstanceState(Activity.java:1186)
android.app.Instrumentation.callActivityOnSaveInstanceState(Instrumentation.java:1240)
android.app.ActivityThread.performStopActivityInner(ActivityThread.java:3309)
android.app.ActivityThread.handleStopActivity(ActivityThread.java:3369)
android.app.ActivityThread.access$1000(ActivityThread.java:159)
android.app.ActivityThread$H.handleMessage(ActivityThread.java:1338)
android.os.Handler.dispatchMessage(Handler.java:99)
android.os.Looper.loop(Looper.java:176)
android.app.ActivityThread.main(ActivityThread.java:5419)
java.lang.reflect.Method.invokeNative(Native Method)
java.lang.reflect.Method.invoke(Method.java:525)
com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:1046)
com.android.internal.os.ZygoteInit.main(ZygoteInit.java:862)
dalvik.system.NativeStart.main(Native Method)
