### PR TITLE
use the internal removeSpan function for removing spans, and also use the proper removeSpan function to delete them

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -717,8 +717,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
             }
         }
 
-        //Add 1 to the end because we put a " " at the end of the spans when adding them
-        text.delete(text.getSpanStart(span), text.getSpanEnd(span) + 1);
+		text.removeSpan(span);
     }
 
     private void updateHint() {
@@ -980,7 +979,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
     private class TokenTextWatcher implements TextWatcher {
 
         protected void removeToken(TokenImageSpan token, Editable text) {
-            text.removeSpan(token);
+			removeSpan(token);
         }
 
         @Override


### PR DESCRIPTION
I was having issues with the proper listener callbacks not being called when backspacing to remove a span / token. It seems when removing the library was prematurely deleting the span instead of going through the internal removeSpan function for removal and calling the listener callback. It also seemed to not use the correct way of removing the span within the removeSpan function so when moving over exceptions would be thrown.

I'm unsure if this is the best way for fixing it, however the way the library worked before seems incorrect if when removing a token, the remove token callback is not called.
