### PR TITLE
Use generics instead of unchecked casts for more type-safety (updated)

### DIFF
--- a/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
@@ -15,7 +15,7 @@ import android.widget.TextView;
  * Created on 9/12/13.
  * @author mgod
  */
-public class ContactsCompletionView extends TokenCompleteTextView {
+public class ContactsCompletionView extends TokenCompleteTextView<Person> {
 
     public ContactsCompletionView(Context context) {
         super(context);
@@ -30,18 +30,17 @@ public class ContactsCompletionView extends TokenCompleteTextView {
     }
 
     @Override
-    protected View getViewForObject(Object object) {
-        Person p = (Person)object;
+    protected View getViewForObject(Person person) {
 
         LayoutInflater l = (LayoutInflater)getContext().getSystemService(Activity.LAYOUT_INFLATER_SERVICE);
         LinearLayout view = (LinearLayout)l.inflate(R.layout.contact_token, (ViewGroup)ContactsCompletionView.this.getParent(), false);
-        ((TextView)view.findViewById(R.id.name)).setText(p.getEmail());
+        ((TextView)view.findViewById(R.id.name)).setText(person.getEmail());
 
         return view;
     }
 
     @Override
-    protected Object defaultObject(String completionText) {
+    protected Person defaultObject(String completionText) {
         //Stupid simple example of guessing if we have an email or not
         int index = completionText.indexOf('@');
         if (index == -1) {

--- a/example/src/main/java/com/tokenautocomplete/TokenActivity.java
+++ b/example/src/main/java/com/tokenautocomplete/TokenActivity.java
@@ -48,9 +48,9 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
             }
 
             @Override
-            protected boolean keepObject(Person obj, String mask) {
+            protected boolean keepObject(Person person, String mask) {
                 mask = mask.toLowerCase();
-                return obj.getName().toLowerCase().startsWith(mask) || obj.getEmail().toLowerCase().startsWith(mask);
+                return person.getName().toLowerCase().startsWith(mask) || person.getEmail().toLowerCase().startsWith(mask);
             }
         };
 
@@ -68,9 +68,9 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
         removeButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                List<Object> objects = completionView.getObjects();
-                if (objects.size() > 0) {
-                    completionView.removeObject(objects.get(objects.size() - 1));
+                List<Person> people = completionView.getObjects();
+                if (people.size() > 0) {
+                    completionView.removeObject(people.get(people.size() - 1));
                 }
             }
         });

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -15,6 +15,11 @@ android {
             minifyEnabled false
         }
     }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_7
+        targetCompatibility JavaVersion.VERSION_1_7
+    }
 }
 
 task jar(type: Jar) {

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -80,7 +80,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     private TokenListener listener;
     private TokenSpanWatcher spanWatcher;
     private ArrayList<T> objects;
-    private List<TokenImageSpan> hiddenSpans;
+    private List<TokenCompleteTextView<T>.TokenImageSpan> hiddenSpans;
     private TokenDeleteStyle deletionStyle = TokenDeleteStyle._Parent;
     private TokenClickStyle tokenClickStyle = TokenClickStyle.None;
     private String prefix = "";
@@ -629,11 +629,11 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
                     text.setSpan(cs, lastPosition, lastPosition + cs.text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
                     // Remove all spans behind the count span and hold them in the hiddenSpans List
-                    // We have to put the newlyHiddenSpans in a separate variable first to coerce to the proper generic type
-                    TokenImageSpan[] newlyHiddenSpans = text.getSpans(lastPosition + cs.text.length(), text.length(), TokenImageSpan.class);
-                    hiddenSpans = Arrays.asList(newlyHiddenSpans);
+                    // The generic type information is not captured in TokenImageSpan.class so we have
+                    // to perform a cast for the returned spans to coerce them to the proper generic type.
+                    hiddenSpans = new ArrayList<>(Arrays.asList(
+                            (TokenImageSpan[])text.getSpans(lastPosition + cs.text.length(), text.length(), TokenImageSpan.class)));
                     for(TokenImageSpan span : hiddenSpans) {
-                        hiddenSpans.add(span);
                         removeSpan(span);
                     }
                 }

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -629,8 +629,11 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
                     text.setSpan(cs, lastPosition, lastPosition + cs.text.length(), Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 
                     // Remove all spans behind the count span and hold them in the hiddenSpans List
-                    hiddenSpans = new ArrayList<>(Arrays.asList(text.getSpans(lastPosition+cs.text.length(), text.length(), TokenImageSpan.class)));
+                    // We have to put the newlyHiddenSpans in a separate variable first to coerce to the proper generic type
+                    TokenImageSpan[] newlyHiddenSpans = text.getSpans(lastPosition + cs.text.length(), text.length(), TokenImageSpan.class);
+                    hiddenSpans = Arrays.asList(newlyHiddenSpans);
                     for(TokenImageSpan span : hiddenSpans) {
+                        hiddenSpans.add(span);
                         removeSpan(span);
                     }
                 }
@@ -879,7 +882,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
      * @param object Object to create a span for
      * @param sourceText CharSequence to show when the span is removed
      */
-    private void insertSpan(Object object, CharSequence sourceText) {
+    private void insertSpan(T object, CharSequence sourceText) {
         SpannableStringBuilder ssb = buildSpannableForText(sourceText);
         TokenImageSpan tokenSpan = buildSpanForObject(object);
 
@@ -916,7 +919,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
 
     }
 
-    private void insertSpan(Object object) {
+    private void insertSpan(T object) {
         insertSpan(object, object.toString());
     }
 
@@ -1072,8 +1075,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     private class TokenSpanWatcher implements SpanWatcher {
 
         @Override
-        public void onSpanAdded(Spannable text, T what, int start, int end) {
-            if (what instanceof TokenImageSpan && !savingState && !focusChanging) {
+        public void onSpanAdded(Spannable text, Object what, int start, int end) {
+            if (what instanceof TokenCompleteTextView<?>.TokenImageSpan && !savingState && !focusChanging) {
                 TokenImageSpan token = (TokenImageSpan)what;
                 objects.add(token.getToken());
 
@@ -1085,7 +1088,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         @SuppressWarnings("unchecked cast")
         @Override
         public void onSpanRemoved(Spannable text, Object what, int start, int end) {
-            if (what instanceof TokenImageSpan && !savingState  && !focusChanging) {
+            if (what instanceof TokenCompleteTextView<?>.TokenImageSpan && !savingState  && !focusChanging) {
                 TokenImageSpan token = (TokenImageSpan)what;
                 if (objects.contains(token.getToken())) {
                     objects.remove(token.getToken());

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -48,7 +48,7 @@ import java.util.List;
  *
  * @author mgod
  */
-public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView implements TextView.OnEditorActionListener {
+public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView implements TextView.OnEditorActionListener {
     //When the token is deleted...
     public enum TokenDeleteStyle {
         _Parent, //...do the parent behavior, not recommended
@@ -76,10 +76,10 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
 
     private char[] splitChar = {',', ';'};
     private Tokenizer tokenizer;
-    private Object selectedObject;
+    private T selectedObject;
     private TokenListener listener;
     private TokenSpanWatcher spanWatcher;
-    private ArrayList<Object> objects;
+    private ArrayList<T> objects;
     private List<TokenImageSpan> hiddenSpans;
     private TokenDeleteStyle deletionStyle = TokenDeleteStyle._Parent;
     private TokenClickStyle tokenClickStyle = TokenClickStyle.None;
@@ -252,7 +252,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      *
      * @return List of tokens
      */
-    public List<Object> getObjects() {
+    public List<T> getObjects() {
         return objects;
     }
 
@@ -342,7 +342,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      * @param object the object selected by the user from the list
      * @return a view to display a token in the text field for the object
      */
-    abstract protected View getViewForObject(Object object);
+    abstract protected View getViewForObject(T object);
 
     /**
      * Provides a default completion when the user hits , and there is no item in the completion
@@ -351,7 +351,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      * @param completionText the current text we are completing against
      * @return a best guess for what the user meant to complete
      */
-    abstract protected Object defaultObject(String completionText);
+    abstract protected T defaultObject(String completionText);
 
     protected String currentCompletionText() {
         if (hintVisible) return ""; //Can't have any text if the hint is visible
@@ -686,9 +686,10 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         if(allowCollapse) performCollapse(hasFocus);
     }
 
+    @SuppressWarnings("unchecked cast")
     @Override
     protected CharSequence convertSelectionToString(Object object) {
-        selectedObject = object;
+        selectedObject = (T) object;
 
         //if the token gets deleted, this text will get put in the field instead
         switch (deletionStyle) {
@@ -713,7 +714,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         return new SpannableStringBuilder(String.valueOf(sentinel) + tokenizer.terminateToken(text));
     }
 
-    protected TokenImageSpan buildSpanForObject(Object obj) {
+    protected TokenImageSpan buildSpanForObject(T obj) {
         if (obj == null) {
             return null;
         }
@@ -767,7 +768,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      * @param object the object to add to the displayed tokens
      * @param sourceText the text used if this object is deleted
      */
-    public void addObject(final Object object, final CharSequence sourceText) {
+    public void addObject(final T object, final CharSequence sourceText) {
         post(new Runnable() {
             @Override
             public void run() {
@@ -784,7 +785,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      *
      * @param object the object to add to the displayed token
      */
-    public void addObject(Object object) {
+    public void addObject(T object) {
         addObject(object, "");
     }
 
@@ -794,8 +795,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
      *
      * @param object object to remove, may be null or not in the view
      */
-    @SuppressWarnings("unused")
-    public void removeObject(final Object object) {
+    public void removeObject(final T object) {
         post(new Runnable() {
             @Override
             public void run() {
@@ -1019,14 +1019,14 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
     }
 
     protected class TokenImageSpan extends ViewSpan {
-        private Object token;
+        private T token;
 
-        public TokenImageSpan(View d, Object token, int maxWidth) {
+        public TokenImageSpan(View d, T token, int maxWidth) {
             super(d, maxWidth);
             this.token = token;
         }
 
-        public Object getToken() {
+        public T getToken() {
             return this.token;
         }
 
@@ -1064,15 +1064,15 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         }
     }
 
-    public static interface TokenListener {
-        public void onTokenAdded(Object token);
-        public void onTokenRemoved(Object token);
+    public static interface TokenListener<T> {
+        public void onTokenAdded(T token);
+        public void onTokenRemoved(T token);
     }
 
     private class TokenSpanWatcher implements SpanWatcher {
 
         @Override
-        public void onSpanAdded(Spannable text, Object what, int start, int end) {
+        public void onSpanAdded(Spannable text, T what, int start, int end) {
             if (what instanceof TokenImageSpan && !savingState && !focusChanging) {
                 TokenImageSpan token = (TokenImageSpan)what;
                 objects.add(token.getToken());
@@ -1082,6 +1082,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
             }
         }
 
+        @SuppressWarnings("unchecked cast")
         @Override
         public void onSpanRemoved(Spannable text, Object what, int start, int end) {
             if (what instanceof TokenImageSpan && !savingState  && !focusChanging) {
@@ -1169,8 +1170,8 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
     }
 
     @SuppressWarnings("unchecked")
-    protected ArrayList<Object> convertSerializableArrayToObjectArray(ArrayList<Serializable> s) {
-        return (ArrayList<Object>)(ArrayList)s;
+    protected ArrayList<T> convertSerializableArrayToObjectArray(ArrayList<Serializable> s) {
+        return (ArrayList<T>)(ArrayList)s;
     }
 
     @Override
@@ -1217,7 +1218,7 @@ public abstract class TokenCompleteTextView extends MultiAutoCompleteTextView im
         splitChar = ss.splitChar;
 
         resetListeners();
-        for (Object obj: convertSerializableArrayToObjectArray(ss.baseObjects)) {
+        for (T obj: convertSerializableArrayToObjectArray(ss.baseObjects)) {
             addObject(obj);
         }
 


### PR DESCRIPTION
I've rebased the original pull request #47 to the current master and made some additional changes to get it working.

As mentioned in #47 there was an issue with the TokenImageSpan inner class. This was resolved with an explicit cast in 7de557b.

This was tested on the example app and on my own project.