### PR TITLE
Fix Backspace Issue on newly created Tokens

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1133,7 +1133,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             clearSelections();
             updateHint();
 
-            TokenImageSpan[] spans = text.getSpans(start - before, start - before + count, TokenImageSpan.class);
+            TokenImageSpan[] spans = text.getSpans(start - before, start + Math.max(before, count), TokenImageSpan.class);
 
             for (TokenImageSpan token: spans) {
 


### PR DESCRIPTION
This fix addresses an issue I ran into while trying to incorporate the library into a project I am working on.  If you backspace into a newly created token, the token does not revert to its autocomplete text for editing.  Instead, the space after the token is removed, but the token remains.  Typing new text,  then hitting comma again will cause the new text to be combined into the token with the old text.

To experience this issue in the Example app:
1. Enter 'foo', then hit comma. A token appears labeled "foo@example.com".
2. Tap backspace on the keyboard. 
3. Enter 'bar', then hit comma.  

Observed Behavior:
    The existing "foo@example.com" token becomes "foobar@example.com".

Expected Behavior:
        The "foo@example.com" token is removed when the backspace is tapped and replaced with the text "foo".

This fix  addresses this issue by modifying the TokenTextWatcher to change the range of spans it searches for.  The existing range doesn't include the range covered by the last token.  Thus, the final token is never removed and replaced by its text.