### PR TITLE
Placement of added objects while entering text

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -903,7 +903,13 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
                 offset = prefix.length();
                 editable.insert(offset, ssb);
             } else {
-                editable.append(ssb);
+                String completionText = currentCompletionText();
+                if ( completionText  != null && completionText.length() > 0 ) {
+                    // The user has entered some text that has not yet been tokenized.
+                    // Find the beginning of this text and insert the new token there.
+                    offset = TextUtils.indexOf(editable, completionText);
+                }
+                editable.insert(offset, ssb);
             }
             editable.setSpan(tokenSpan, offset, offset + ssb.length() - 1, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE);
 


### PR DESCRIPTION
If the user is typing text into the Token field when the app decides to add an object to the field (such as during a background update), the tokens appear after the text the user is editing, preventing them from finishing the data entry.

This fix updates the insertSpan method so that all inserted spans are place before any text the user is currently entering, but which hasn't yet been committed into a token.

To reproduce this issue in the Example app:
1. Enter some text, such as "foo"
2. Tap the "Add random token" button

Observed  result:
    The new token is added at the end of the token field, after the untokenized text the user was entering.

Expected result:
    The new token appears at the end of the list of tokens, but before any untokenized text the user is entering.