### PR TITLE
Tag tokens now selectable.

### DIFF
--- a/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
@@ -3,6 +3,7 @@ package com.tokenautocomplete;
 import android.app.Activity;
 import android.content.Context;
 import android.util.AttributeSet;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -19,14 +20,17 @@ public class ContactsCompletionView extends TokenCompleteTextView<Person> {
 
     public ContactsCompletionView(Context context) {
         super(context);
+        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     public ContactsCompletionView(Context context, AttributeSet attrs) {
         super(context, attrs);
+        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     public ContactsCompletionView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
+        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     @Override

--- a/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
@@ -3,7 +3,6 @@ package com.tokenautocomplete;
 import android.app.Activity;
 import android.content.Context;
 import android.util.AttributeSet;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;

--- a/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
@@ -19,17 +19,14 @@ public class ContactsCompletionView extends TokenCompleteTextView<Person> {
 
     public ContactsCompletionView(Context context) {
         super(context);
-        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     public ContactsCompletionView(Context context, AttributeSet attrs) {
         super(context, attrs);
-        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     public ContactsCompletionView(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
-        setTokenClickStyle(TokenClickStyle.Select);
     }
 
     @Override

--- a/example/src/main/java/com/tokenautocomplete/TokenActivity.java
+++ b/example/src/main/java/com/tokenautocomplete/TokenActivity.java
@@ -57,6 +57,8 @@ public class TokenActivity extends Activity implements TokenCompleteTextView.Tok
         completionView = (ContactsCompletionView)findViewById(R.id.searchView);
         completionView.setAdapter(adapter);
         completionView.setTokenListener(this);
+        completionView.setTokenClickStyle(TokenCompleteTextView.TokenClickStyle.Select);
+
 
         if (savedInstanceState == null) {
             completionView.setPrefix("To: ");


### PR DESCRIPTION
The original example did not allow me to select the tag tokens. I added the "setTokenClickStyle(TokenClickStyle.Select)" to the ContactsCompletionView in order to allow the tags to be selectable. This then activates the color change and "x" image to be shown on the tags. Clicking again lets you delete the tag.

@mgod  Not sure if you wanted me to add this in the example, but I added the "setTokenClickStyle(TokenClickStyle.Select)" into the TokenActivity class.