### PR TITLE
Fixed potential activity leak in onSavedState.

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -13,6 +13,7 @@ import android.text.Editable;
 import android.text.InputFilter;
 import android.text.InputType;
 import android.text.Layout;
+import android.text.NoCopySpan;
 import android.text.Selection;
 import android.text.SpanWatcher;
 import android.text.Spannable;
@@ -1177,7 +1178,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         invalidate();
     }
 
-    protected class TokenImageSpan extends ViewSpan {
+    protected class TokenImageSpan extends ViewSpan implements NoCopySpan {
         private T token;
 
         public TokenImageSpan(View d, T token, int maxWidth) {


### PR DESCRIPTION
Parent text view stores copy of spannable text builder in saved state during onSavedState which indirectly leaks activity:
SpannableStringBuilder.mSpans -> TokenImageSpan -> mView -> ... -> activity
unless spans are marked with NoCopySpan. onRestoreInstanceState is recreating span views already, no change required.

This leak can be seen if recreated activity keeps reference to saved state acquired in onCreate(Bundle).