### PR TITLE
Adding clearCompletionText method

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -461,6 +461,23 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         return description;
     }
 
+    /**
+     * Clear the completion text only.
+     */
+    @SuppressWarnings("unused")
+    public void clearCompletionText() {
+        //Respect currentCompletionText in case hint is visible or if other checks are added.
+        if (currentCompletionText().length() == 0){
+            return;
+        }
+
+        Editable editable = getText();
+        int end = getCorrectedTokenEnd();
+        int start = getCorrectedTokenBeginning(end);
+
+        editable.delete(start, end);
+    }
+
     @Override
     public void onInitializeAccessibilityEvent(AccessibilityEvent event) {
         super.onInitializeAccessibilityEvent(event);


### PR DESCRIPTION
I couldn't figure out if there was a way to clear the completion text only and leave the tokens, so I added a method. Was I missing anything?

Are you interested in adding this or have any comments about the implementation?
