### PR TITLE
Making class TokenImageSpan public

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1198,7 +1198,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         invalidate();
     }
 
-    protected class TokenImageSpan extends ViewSpan implements NoCopySpan {
+    public class TokenImageSpan extends ViewSpan implements NoCopySpan {
         private T token;
 
         public TokenImageSpan(View d, T token, int maxWidth) {


### PR DESCRIPTION
- Made class TokenImageSpan public so that it can be accessed from outside.
- We need this class public so that we can call getSpans() on the EditText.
- Right now, this class is accessible, but crashes at runtime on devices
  with API less than lollipop and which have multidex enabled.