### PR TITLE
references splitwise/TokenAutoComplete#62 Replaces support for Serial…

### DIFF
--- a/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
+++ b/example/src/main/java/com/tokenautocomplete/ContactsCompletionView.java
@@ -6,8 +6,6 @@ import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 
 /**
  * Sample token completion view for basic contact info
@@ -46,5 +44,10 @@ public class ContactsCompletionView extends TokenCompleteTextView<Person> {
         } else {
             return new Person(completionText.substring(0, index), completionText);
         }
+    }
+
+    @Override
+    protected Class<Person> getParcelableClass() {
+        return Person.class;
     }
 }

--- a/example/src/main/java/com/tokenautocomplete/Person.java
+++ b/example/src/main/java/com/tokenautocomplete/Person.java
@@ -1,6 +1,7 @@
 package com.tokenautocomplete;
 
-import java.io.Serializable;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * Simple container object for contact data
@@ -8,7 +9,7 @@ import java.io.Serializable;
  * Created by mgod on 9/12/13.
  * @author mgod
  */
-public class Person implements Serializable{
+public class Person implements Parcelable {
     private String name;
     private String email;
 
@@ -22,4 +23,32 @@ public class Person implements Serializable{
 
     @Override
     public String toString() { return name; }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.name);
+        dest.writeString(this.email);
+    }
+
+    protected Person(Parcel in) {
+        this.name = in.readString();
+        this.email = in.readString();
+    }
+
+    public static final Parcelable.Creator<Person> CREATOR = new Parcelable.Creator<Person>() {
+        @Override
+        public Person createFromParcel(Parcel source) {
+            return new Person(source);
+        }
+
+        @Override
+        public Person[] newArray(int size) {
+            return new Person[size];
+        }
+    };
 }

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -3,7 +3,6 @@ package com.tokenautocomplete;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.ColorStateList;
-import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -42,7 +41,6 @@ import android.widget.ListView;
 import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1377,32 +1375,36 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         }
     }
 
-    protected ArrayList<Serializable> getSerializableObjects() {
-        ArrayList<Serializable> serializables = new ArrayList<>();
+    protected ArrayList<Parcelable> getParcelableObjects() {
+        ArrayList<Parcelable> parcelables = new ArrayList<>();
         for (Object obj : getObjects()) {
-            if (obj instanceof Serializable) {
-                serializables.add((Serializable) obj);
+            if (obj instanceof Parcelable) {
+                parcelables.add((Parcelable) obj);
             } else {
                 Log.e(TAG, "Unable to save '" + obj + "'");
+                return new ArrayList<>();
             }
         }
-        if (serializables.size() != objects.size()) {
-            String message = "You should make your objects Serializable or override\n" +
-                    "getSerializableObjects and convertSerializableArrayToObjectArray";
+        if (parcelables.size() != objects.size()) {
+            String message = "Your objects are not Parcelable and won't be automatically saved and " +
+                    "restored.";
             Log.e(TAG, message);
         }
-
-        return serializables;
+        return parcelables;
     }
 
-    @SuppressWarnings("unchecked")
-    protected ArrayList<T> convertSerializableArrayToObjectArray(ArrayList<Serializable> s) {
-        return (ArrayList<T>) (ArrayList) s;
-    }
+    /**
+     * In order to safely parcel objects, we must know the actual class type of the objects.
+     * Subclasses are forced to implement this method, and should return a Class object for
+     * type T.
+     *
+     * @return A Class object for type T.
+     */
+    protected abstract Class<T> getParcelableClass();
 
     @Override
     public Parcelable onSaveInstanceState() {
-        ArrayList<Serializable> baseObjects = getSerializableObjects();
+        ArrayList<Parcelable> baseObjects = getParcelableObjects();
 
         //We don't want to save the listeners as part of the parent
         //onSaveInstanceState, so remove them first
@@ -1423,6 +1425,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         state.tokenDeleteStyle = deletionStyle;
         state.baseObjects = baseObjects;
         state.splitChar = splitChar;
+        state.parcelableClass = getParcelableClass();
 
         //So, when the screen is locked or some other system event pauses execution,
         //onSaveInstanceState gets called, but it won't restore state later because the
@@ -1456,8 +1459,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         splitChar = ss.splitChar;
 
         addListeners();
-        for (T obj : convertSerializableArrayToObjectArray(ss.baseObjects)) {
-            addObject(obj);
+        for (Parcelable obj : ss.baseObjects) {
+            addObject((T) obj);
         }
 
         // Collapse the view if necessary
@@ -1482,8 +1485,9 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         boolean performBestGuess;
         TokenClickStyle tokenClickStyle;
         TokenDeleteStyle tokenDeleteStyle;
-        ArrayList<Serializable> baseObjects;
+        ArrayList<Parcelable> baseObjects;
         char[] splitChar;
+        Class parcelableClass;
 
         @SuppressWarnings("unchecked")
         SavedState(Parcel in) {
@@ -1494,7 +1498,11 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             performBestGuess = in.readInt() != 0;
             tokenClickStyle = TokenClickStyle.values()[in.readInt()];
             tokenDeleteStyle = TokenDeleteStyle.values()[in.readInt()];
-            baseObjects = (ArrayList<Serializable>) in.readSerializable();
+            if (parcelableClass != null) {
+                in.readList(baseObjects, parcelableClass.getClassLoader());
+            } else {
+                baseObjects = new ArrayList<>();
+            }
             splitChar = in.createCharArray();
         }
 
@@ -1511,7 +1519,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             out.writeInt(performBestGuess ? 1 : 0);
             out.writeInt(tokenClickStyle.ordinal());
             out.writeInt(tokenDeleteStyle.ordinal());
-            out.writeSerializable(baseObjects);
+            out.writeTypedList(baseObjects);
             out.writeCharArray(splitChar);
         }
 


### PR DESCRIPTION
Replaces support for Serializable with support for Parcelable

- Replaces support for Serializable with Parcelable, for better compatibility with existing Android projects already using Parcelable.

I read up on the issue posted 2 years ago, and I understand your hesitation against Parcelable, especially because, as you rightly pointed out, the speed difference is fairly negligible for what most people use this for and Serializable is usually easier to implement.

However, I believe the fact that the vast majority of Android projects are already using Parcelable is a huge reason to allow this to, instead of forcing POJOs to implement both. Also, even though the speed difference is negligible in most cases, some people may see large performance improvements.

This is a breaking change. If you do so decide to merge this, people will be forced to, at the very least, implement the new method I added. I believe most, if not all people, would want the save/restore functionality, which is why I didn't provide a default implementation. Also, any one current using Serializable will no longer have the save/restore functionality. Having them both in the code seemed too extra, in my opinion. 