### PR TITLE
Add direct support for saving Parcelable objects in view state

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,15 +2,15 @@
 
 buildscript {
     repositories {
-        mavenCentral()
+        jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.3'
+        classpath 'com.android.tools.build:gradle:2.3.3'
     }
 }
 
 allprojects {
     repositories {
-        mavenCentral()
+        jcenter()
     }
 }

--- a/example/src/main/java/com/tokenautocomplete/Person.java
+++ b/example/src/main/java/com/tokenautocomplete/Person.java
@@ -1,6 +1,7 @@
 package com.tokenautocomplete;
 
-import java.io.Serializable;
+import android.os.Parcel;
+import android.os.Parcelable;
 
 /**
  * Simple container object for contact data
@@ -8,18 +9,46 @@ import java.io.Serializable;
  * Created by mgod on 9/12/13.
  * @author mgod
  */
-public class Person implements Serializable{
+class Person implements Parcelable {
     private String name;
     private String email;
 
-    public Person(String n, String e) {
+    Person(String n, String e) {
         name = n;
         email = e;
     }
 
     public String getName() { return name; }
-    public String getEmail() { return email; }
+    String getEmail() { return email; }
 
     @Override
     public String toString() { return name; }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeString(this.name);
+        dest.writeString(this.email);
+    }
+
+    private Person(Parcel in) {
+        this.name = in.readString();
+        this.email = in.readString();
+    }
+
+    public static final Parcelable.Creator<Person> CREATOR = new Parcelable.Creator<Person>() {
+        @Override
+        public Person createFromParcel(Parcel source) {
+            return new Person(source);
+        }
+
+        @Override
+        public Person[] newArray(int size) {
+            return new Person[size];
+        }
+    };
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,14 +17,14 @@
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
 
-VERSION_NAME=2.0.8
-VERSION_CODE=14
+VERSION_NAME=2.1
+VERSION_CODE=15
 GROUP=com.splitwise
 
 ANDROID_BUILD_MIN_SDK_VERSION=14
-ANDROID_BUILD_TARGET_SDK_VERSION=21
-ANDROID_BUILD_SDK_VERSION=21
-ANDROID_BUILD_TOOLS_VERSION=23.0.2
+ANDROID_BUILD_TARGET_SDK_VERSION=25
+ANDROID_BUILD_SDK_VERSION=25
+ANDROID_BUILD_TOOLS_VERSION=25.0.3
 
 POM_DESCRIPTION=Android Token AutoComplete EditText
 POM_URL=https://github.com/splitwise/TokenAutoComplete

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Sep 16 11:36:56 EDT 2016
+#Tue Jul 25 10:33:59 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -23,14 +23,14 @@ android {
 }
 
 task jar(type: Jar) {
-    dependsOn assembleRelease
+    dependsOn 'assembleRelease'
     baseName project.POM_ARTIFACT_ID
     version project.VERSION_NAME
     from fileTree(dir: 'build/intermediates/classes/release/')
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:23.1.1'
+    compile 'com.android.support:support-annotations:25.3.1'
 }
 
 apply from: 'https://raw.github.com/chrisbanes/gradle-mvn-push/master/gradle-mvn-push.gradle'

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -40,6 +40,8 @@ import android.widget.MultiAutoCompleteTextView;
 import android.widget.TextView;
 
 import java.io.Serializable;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -1353,8 +1355,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         }
     }
 
-    protected ArrayList<Serializable> getSerializableObjects() {
-        ArrayList<Serializable> serializables = new ArrayList<>();
+    protected List<Serializable> getSerializableObjects() {
+        List<Serializable> serializables = new ArrayList<>();
         for (Object obj : getObjects()) {
             if (obj instanceof Serializable) {
                 serializables.add((Serializable) obj);
@@ -1363,8 +1365,8 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             }
         }
         if (serializables.size() != objects.size()) {
-            String message = "You should make your objects Serializable or override\n" +
-                    "getSerializableObjects and convertSerializableArrayToObjectArray";
+            String message = "You should make your objects Serializable or Parcelable or\n" +
+                    "override getSerializableObjects and convertSerializableArrayToObjectArray";
             Log.e(TAG, message);
         }
 
@@ -1372,14 +1374,29 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     }
 
     @SuppressWarnings("unchecked")
-    protected ArrayList<T> convertSerializableArrayToObjectArray(ArrayList<Serializable> s) {
-        return (ArrayList<T>) (ArrayList) s;
+    protected List<T> convertSerializableObjectsToTypedObjects(List s) {
+        return (List<T>) s;
+    }
+
+    //Used to determine if we can use the Parcelable interface
+    private Class reifyParameterizedTypeClass() {
+        //Borrowed from http://codyaray.com/2013/01/finding-generic-type-parameters-with-guava
+
+        //Figure out what class of objects we have
+        Class<?> viewClass = getClass();
+        while (!viewClass.getSuperclass().equals(TokenCompleteTextView.class)) {
+            viewClass = viewClass.getSuperclass();
+        }
+
+        // This operation is safe. Because viewClass is a direct sub-class, getGenericSuperclass() will
+        // always return the Type of this class. Because this class is parameterized, the cast is safe
+        ParameterizedType superclass = (ParameterizedType) viewClass.getGenericSuperclass();
+        Type type = superclass.getActualTypeArguments()[0];
+        return (Class)type;
     }
 
     @Override
     public Parcelable onSaveInstanceState() {
-        ArrayList<Serializable> baseObjects = getSerializableObjects();
-
         //We don't want to save the listeners as part of the parent
         //onSaveInstanceState, so remove them first
         removeListeners();
@@ -1397,7 +1414,16 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         state.performBestGuess = performBestGuess;
         state.tokenClickStyle = tokenClickStyle;
         state.tokenDeleteStyle = deletionStyle;
-        state.baseObjects = baseObjects;
+        Class parameterizedClass = reifyParameterizedTypeClass();
+        //Our core array is Parcelable, so use that interface
+        if (Parcelable.class.isAssignableFrom(parameterizedClass)) {
+            state.parcelableClassName = parameterizedClass.getName();
+            state.baseObjects = getObjects();
+        } else {
+            //Fallback on Serializable
+            state.parcelableClassName = SavedState.SERIALIZABLE_PLACEHOLDER;
+            state.baseObjects = getSerializableObjects();
+        }
         state.splitChar = splitChar;
 
         //So, when the screen is locked or some other system event pauses execution,
@@ -1430,9 +1456,16 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         tokenClickStyle = ss.tokenClickStyle;
         deletionStyle = ss.tokenDeleteStyle;
         splitChar = ss.splitChar;
-
         addListeners();
-        for (T obj : convertSerializableArrayToObjectArray(ss.baseObjects)) {
+
+        List<T> objects;
+        if (SavedState.SERIALIZABLE_PLACEHOLDER.equals(ss.parcelableClassName)) {
+            objects = convertSerializableObjectsToTypedObjects(ss.baseObjects);
+        } else {
+            objects = (List<T>)ss.baseObjects;
+        }
+
+        for (T obj: objects) {
             addObject(obj);
         }
 
@@ -1452,13 +1485,16 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
      * Handle saving the token state
      */
     private static class SavedState extends BaseSavedState {
+        static final String SERIALIZABLE_PLACEHOLDER = "Serializable";
+
         CharSequence prefix;
         boolean allowCollapse;
         boolean allowDuplicates;
         boolean performBestGuess;
         TokenClickStyle tokenClickStyle;
         TokenDeleteStyle tokenDeleteStyle;
-        ArrayList<Serializable> baseObjects;
+        String parcelableClassName;
+        List<?> baseObjects;
         char[] splitChar;
 
         @SuppressWarnings("unchecked")
@@ -1470,7 +1506,18 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             performBestGuess = in.readInt() != 0;
             tokenClickStyle = TokenClickStyle.values()[in.readInt()];
             tokenDeleteStyle = TokenDeleteStyle.values()[in.readInt()];
-            baseObjects = (ArrayList<Serializable>) in.readSerializable();
+            parcelableClassName = in.readString();
+            if (SERIALIZABLE_PLACEHOLDER.equals(parcelableClassName)) {
+                baseObjects = (ArrayList)in.readSerializable();
+            } else {
+                try {
+                    ClassLoader loader = Class.forName(parcelableClassName).getClassLoader();
+                    baseObjects = in.readArrayList(loader);
+                } catch (ClassNotFoundException ex) {
+                    //This should really never happen, class had to be available to get here
+                    throw new RuntimeException(ex);
+                }
+            }
             splitChar = in.createCharArray();
         }
 
@@ -1487,7 +1534,13 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
             out.writeInt(performBestGuess ? 1 : 0);
             out.writeInt(tokenClickStyle.ordinal());
             out.writeInt(tokenDeleteStyle.ordinal());
-            out.writeSerializable(baseObjects);
+            if (SERIALIZABLE_PLACEHOLDER.equals(parcelableClassName)) {
+                out.writeString(SERIALIZABLE_PLACEHOLDER);
+                out.writeSerializable((Serializable)baseObjects);
+            } else {
+                out.writeString(parcelableClassName);
+                out.writeList(baseObjects);
+            }
             out.writeCharArray(splitChar);
         }
 


### PR DESCRIPTION
Close #17. Close #62.

This change uses reflection to determine if we can use ```Parcelable``` instead of ```Serializable``` when saving and restoring view state. It will check if the generic type ```T``` conforms to the ```Parcelable``` interface and use that to save and restore the objects instead of the ```Serializable``` implementation. Falls back on the ```Serializable``` code if type ```T``` is not ```Parcelable```.

As we are adding reflection and usually expect to have a small number of objects, this is probably not a performance improvement, but it will allow developers who are currently using ```Parcelable``` objects to not need to do anything special to get reasonable save/restore behavior.