### PR TITLE
New option completeOnFocusLost

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,10 @@ setThreshold(1);
 ```java
 setTokenLimit(10);
 ```
+* Turn off completing unfinished tokens when the view loses focus
+```java
+completeOnFocusLost(false);
+```
 * Prevent specific tokens from being deleted by overriding ```isTokenRemovable``` on your completion view
 
 

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -411,7 +411,9 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     }
 
     /**
-     * Set whether we should try to complete any unfinished tokens when the view loses focus.
+     * Set whether we should try to complete any unfinished tokens when the view loses focus. If the
+     * current text is a valid email string, a new token is generated regardless of the value of
+     * this variable.
      *
      * @param completeOnFocusLost true if it should complete any unfinished tokens after losing
      *                            focus, othewise leave the remaining text as is.
@@ -438,6 +440,10 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
      * @return a best guess for what the user meant to complete
      */
     abstract protected T defaultObject(String completionText);
+
+    private boolean isValidEmail(String emailString) {
+       return android.util.Patterns.EMAIL_ADDRESS.matcher(emailString).matches();
+    }
 
     /**
      * Correctly build accessibility string for token contents
@@ -875,7 +881,9 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         super.onFocusChanged(hasFocus, direction, previous);
 
         // See if the user left any unfinished tokens and finish them
-        if (completeOnFocusLost && !hasFocus) performCompletion();
+        boolean shouldCompleteOnFocusLost = completeOnFocusLost
+                                            || isValidEmail(currentCompletionText());
+        if (shouldCompleteOnFocusLost && !hasFocus) performCompletion();
 
         // Clear sections when focus changes to avoid a token remaining selected
         clearSelections();

--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -105,6 +105,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     private boolean savingState = false;
     private boolean shouldFocusNext = false;
     private boolean allowCollapse = true;
+    private boolean completeOnFocusLost = true;
 
     private int tokenLimit = -1;
 
@@ -409,6 +410,18 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         this.tokenLimit = tokenLimit;
     }
 
+    /**
+     * Set whether we should try to complete any unfinished tokens when the view loses focus.
+     *
+     * @param completeOnFocusLost true if it should complete any unfinished tokens after losing
+     *                            focus, othewise leave the remaining text as is.
+     */
+    @SuppressWarnings("unused")
+    public void completeOnFocusLost(boolean completeOnFocusLost) {
+        this.completeOnFocusLost = completeOnFocusLost;
+    }
+
+    /**
     /**
      * A token view for the object
      *
@@ -862,7 +875,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         super.onFocusChanged(hasFocus, direction, previous);
 
         // See if the user left any unfinished tokens and finish them
-        if (!hasFocus) performCompletion();
+        if (completeOnFocusLost && !hasFocus) performCompletion();
 
         // Clear sections when focus changes to avoid a token remaining selected
         clearSelections();


### PR DESCRIPTION
When set to `false`, this option turns off completing unfinished tokens when the view loses focus. 

The current behavior is that if the user writes something like "gabriel" and the view loses focus, it will automatically be completed with something like "gabriel@gmail.com", Which may not be ok for some users.

When the option is set to `false`, if the user writes something like "gabriel" and the view loses focus, the unfinished token's text remains unchanged, and when the focus returns to the view, autocompletion resumes normailly.

As a plus, if the unfinished token is a valid email adress, then the token is completed when the view loses focus, regardless of the value of `completeOnFocusLost`. Validation is performed using [a regular expression from the Android Plataform](https://developer.android.com/reference/android/util/Patterns.html#EMAIL_ADDRESS).