### PR TITLE
Added clearTextAndTokens()

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1031,6 +1031,46 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
     }
 
     /**
+     * Remove all objects from the token list then clear all stray non-tokenized text from the view.
+     */
+    public void clearTextAndTokens() {
+        post(new Runnable() {
+            @Override
+            public void run() {
+                //To make sure all the appropriate callbacks happen, we just want to piggyback on the
+                //existing code that handles deleting spans when the text changes
+                Editable text = getText();
+                if (text == null) {
+                    return;
+                }
+
+                // Remove all hidden tokens
+                ArrayList<TokenImageSpan> toRemove = new ArrayList<>();
+                for (TokenImageSpan span : hiddenSpans) {
+                    toRemove.add(span);
+                }
+                for (TokenImageSpan span : toRemove) {
+                    hiddenSpans.remove(span);
+                    // Remove it from the state and fire the callback
+                    spanWatcher.onSpanRemoved(text, span, 0, 0);
+                }
+
+                updateCountSpan();
+
+                // Then remove all visible tokens
+                TokenImageSpan[] spans = text.getSpans(0, text.length(), TokenImageSpan.class);
+                for (TokenImageSpan span : spans) {
+                    removeSpan(span);
+                }
+
+                // Finally clear any stray non-tokenized text
+                Parcelable state = TokenCompleteTextView.this.onSaveInstanceState();
+                TokenCompleteTextView.this.onRestoreInstanceState(state);
+            }
+        });
+    }
+    
+    /**
      * Set the count span the current number of hidden objects
      */
     private void updateCountSpan() {


### PR DESCRIPTION
clearTextAndTokens() does what I wanted clear() to do, which is to remove all objects and stray text from a TokenCompleteTextView. The problem is that clear() removes spans instead of objects.
I was unable to safely remove stray text from the view after invoking removeObject() for all objects because it posts a Runnable instead of immediately removing the object.