### PR TITLE
Pass fixed splitChar to CharacterTokenizer

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -332,7 +332,7 @@ public abstract class TokenCompleteTextView<T> extends MultiAutoCompleteTextView
         }
         this.splitChar = fixed;
         // Keep the tokenizer and splitChars in sync
-        this.setTokenizer(new CharacterTokenizer(splitChar));
+        this.setTokenizer(new CharacterTokenizer(this.splitChar));
     }
 
     /**


### PR DESCRIPTION
The special character '§' used to separate tokens when custom split chars are set was not passed to the `CharacterTokenizer`, causing issues when inserting a token before an existing one, as the tokenizer would not correctly recognize the end of the following token.