### PR TITLE
Don't hook into invalidate() to trigger redrawing spans

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/DummySpan.java
+++ b/library/src/main/java/com/tokenautocomplete/DummySpan.java
@@ -1,0 +1,23 @@
+package com.tokenautocomplete;
+
+import android.text.TextPaint;
+import android.text.style.MetricAffectingSpan;
+
+import androidx.annotation.NonNull;
+
+/**
+ * Invisible MetricAffectingSpan that will trigger a redraw when it is being added to or removed from an Editable.
+ *
+ * @see TokenCompleteTextView#redrawTokens()
+ */
+class DummySpan extends MetricAffectingSpan {
+    static final DummySpan INSTANCE = new DummySpan();
+
+    private DummySpan() {}
+
+    @Override
+    public void updateMeasureState(@NonNull TextPaint textPaint) {}
+
+    @Override
+    public void updateDrawState(TextPaint tp) {}
+}


### PR DESCRIPTION
`invalidate()` often triggers additional `invalidate()` calls and it's easy to get into an endless loop or do too much work. Doing additional work in `invalidate()` is also the cause of a crash when cutting all text (#335).

Instead of using an implementation detail of `TextView` to trigger redrawing the spans we now add or remove an invisible dummy span to achieve the same result. This is unlikely to break in the future.

Fixes #335