### PR TITLE
make Range public because it is part of Tokenizer public interface.

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/Range.java
+++ b/library/src/main/java/com/tokenautocomplete/Range.java
@@ -2,7 +2,7 @@ package com.tokenautocomplete;
 
 import java.util.Locale;
 
-class Range {
+public class Range {
     public final int start;
     public final int end;
 


### PR DESCRIPTION
This is pretty trivial, but important if you want to implement Tokenizer outside of this package.   Trying to create a more complex email address tokenizer that uses space as a delimiter if it's after an rfc822 email address.

Issue #412