### PR TITLE
Update Kotlin nullability

### DIFF
--- a/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.kt
+++ b/library/src/main/java/com/tokenautocomplete/TokenCompleteTextView.kt
@@ -1096,6 +1096,7 @@ abstract class TokenCompleteTextView<T: Any> : AppCompatAutoCompleteTextView, On
                 internalEditInProgress = true
                 text.removeSpan(hint)
                 text.replace(sStart, sEnd, "")
+                setSelection(sStart)
                 internalEditInProgress = false
             }
         }


### PR DESCRIPTION
The default kotlin conversion process didn't get all the `null` checks to line up with the expected API use. This should hopefully make them more correctly match expected subclass implementations.

Also fix an issue with the cursor position being wrong when removing the hint for the field with the a prefix set. Before this fix, when the first letter was entered, sometimes the cursor would wind up in front of that letter instead of after it.